### PR TITLE
Fix Win10 terminal ANSI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 # auto-mc-server.py
 
-**[ALPHA]** My own script writing in python that makes it easier for me to set up minecraft servers, my english is bad btw
+**[ALPHA]** My own script writing in python that makes it easier for me to set up minecraft servers, my english is bad
+btw.
 
 ### Usage
 
+On Windows the color support requires: `Computer\HKEY_CURRENT_USER\Console => VirtualTerminalLevel` set to 1.
+If you don't agree, you can disable the function that modifies it. To disable the color support change
+the `color_support=True` line to `False`
+
 ```shell
-# Download the latest script
+# Download the latest version of the script
 $ curl https://raw.githubusercontent.com/nowuX/auto-mc-server.py/dev/script.py -o script.py
 
 # Put the file in the folder you want to use
 $ python script.py
 ```
+
 Not tested enough, may contain bugs.
 
 ### Known Bugs
-- Windows 10 console (CMD/PowerShell) issue with ANSI colors formating (Fixed soon)
+
+- . . .

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```shell
 # Download the latest script
-$ curl -O https://raw.githubusercontent.com/nowuX/auto-mc-server.py/dev/script.py
+$ curl https://raw.githubusercontent.com/nowuX/auto-mc-server.py/dev/script.py -o script.py
 
 # Put the file in the folder you want to use
 $ python script.py

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # auto-mc-server.py
 
-**[ALPHA]** My own script writing in python that makes it easier for me to set up minecraft servers.
+**[ALPHA]** My own script writing in python that makes it easier for me to set up minecraft servers, my english is bad btw
 
 ### Usage
 
 ```shell
+# Download the latest script
+$ curl -O https://raw.githubusercontent.com/nowuX/auto-mc-server.py/dev/script.py
+
 # Put the file in the folder you want to use
 $ python script.py
 ```
 Not tested enough, may contain bugs.
+
+### Known Bugs
+- Windows 10 console (CMD/PowerShell) issue with ANSI colors formating (Fixed soon)

--- a/script.py
+++ b/script.py
@@ -7,16 +7,23 @@ from urllib.request import urlopen
 
 import requests
 
-
+# Disable Colors until i fix windows console issue with ANSI
+# class Colors:
+#     GREEN = '\033[92m'
+#     YELLOW = '\033[93m'
+#     RED = '\033[91m'
+#     LIGHT_GREEN = "\033[1;32m"
+#     LIGHT_GRAY = "\033[0;37m"
+#     BOLD = '\033[1m'
+#     END = '\033[0m'
 class Colors:
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    RED = '\033[91m'
-    LIGHT_GREEN = "\033[1;32m"
-    LIGHT_GRAY = "\033[0;37m"
-    BOLD = '\033[1m'
-    END = '\033[0m'
-
+    GREEN = ''
+    YELLOW = ''
+    RED = ''
+    LIGHT_GREEN = ''
+    LIGHT_GRAY = ''
+    BOLD = ''
+    END = ''
 
 def exception_handler(name: str, exception: Exception):
     first_line = f'{Colors.RED}Something failed in: {Colors.BOLD}{name}{Colors.END}\n'
@@ -86,8 +93,8 @@ def post_mcdr(jar_file: str):
     with open('permission.yml', 'r') as f:
         data = f.readlines()
     nickname = str(input('{}What is the nickname of the server owner? [Skip]:{} '.format(Colors.BOLD, Colors.END)))
-    print('{}Nickname to set: {}{}'.format(Colors.LIGHT_GRAY, nickname, Colors.END))
     if nickname:
+        print('{}Nickname to set: {}{}'.format(Colors.LIGHT_GRAY, nickname, Colors.END))
         data[13] = '- {}\n'.format(nickname)
         with open('permission.yml', 'w') as f:
             f.writelines(data)


### PR DESCRIPTION
- Fixed a bug in Win10 caused by the  terminal native ANSI color support due VirtualTerminalLevel needing to be enable in the Registry.
- Update README.md.